### PR TITLE
Add option to prevent TERM/INT signal handler from being attached

### DIFF
--- a/graceful.go
+++ b/graceful.go
@@ -46,10 +46,10 @@ type Server struct {
 	// side of long lived connections (e.g. websockets) to reconnect.
 	ShutdownInitiated func()
 
-	// HandleStopSignals indicates if the server should automatically shut down
-	// on SIGINT and SIGTERM. If set to false, you must shut down the server
+	// NoSignalHandling prevents graceful from automatically shutting down
+	// on SIGINT and SIGTERM. If set to true, you must shut down the server
 	// manually with Stop().
-	HandleStopSignals bool
+	NoSignalHandling bool
 
 	// interrupt signals the listener to stop serving connections,
 	// and the server to shut down.
@@ -70,22 +70,15 @@ type Server struct {
 // ensure Server conforms to stop.Stopper
 var _ stop.Stopper = (*Server)(nil)
 
-// NewServer constructs a graceful Server with a given underlying net/http server.
-func NewServer(timeout time.Duration, httpServer *http.Server, handleStopSignals bool) *Server {
-	return &Server{
-		Timeout: timeout,
-		Server:  httpServer,
-
-		HandleStopSignals: handleStopSignals,
-	}
-}
-
 // Run serves the http.Handler with graceful shutdown enabled.
 //
 // timeout is the duration to wait until killing active requests and stopping the server.
 // If timeout is 0, the server never times out. It waits for all active requests to finish.
 func Run(addr string, timeout time.Duration, n http.Handler) {
-	srv := NewServer(timeout, &http.Server{Addr: addr, Handler: n}, true)
+	srv := &Server{
+		Timeout: timeout,
+		Server:  &http.Server{Addr: addr, Handler: n},
+	}
 
 	if err := srv.ListenAndServe(); err != nil {
 		if opErr, ok := err.(*net.OpError); !ok || (ok && opErr.Op != "accept") {
@@ -100,7 +93,7 @@ func Run(addr string, timeout time.Duration, n http.Handler) {
 // timeout is the duration to wait until killing active requests and stopping the server.
 // If timeout is 0, the server never times out. It waits for all active requests to finish.
 func ListenAndServe(server *http.Server, timeout time.Duration) error {
-	srv := NewServer(timeout, server, true)
+	srv := &Server{Timeout: timeout, Server: server}
 	return srv.ListenAndServe()
 }
 
@@ -127,7 +120,7 @@ func (srv *Server) ListenAndServe() error {
 // timeout is the duration to wait until killing active requests and stopping the server.
 // If timeout is 0, the server never times out. It waits for all active requests to finish.
 func ListenAndServeTLS(server *http.Server, certFile, keyFile string, timeout time.Duration) error {
-	srv := NewServer(timeout, server, true)
+	srv := &Server{Timeout: timeout, Server: server}
 	return srv.ListenAndServeTLS(certFile, keyFile)
 }
 
@@ -168,7 +161,7 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
 // timeout is the duration to wait until killing active requests and stopping the server.
 // If timeout is 0, the server never times out. It waits for all active requests to finish.
 func Serve(server *http.Server, l net.Listener, timeout time.Duration) error {
-	srv := NewServer(timeout, server, true)
+	srv := &Server{Timeout: timeout, Server: server}
 	return srv.Serve(l)
 }
 
@@ -226,7 +219,7 @@ func (srv *Server) Serve(listener net.Listener) error {
 	}
 
 	// Set up the interrupt handler
-	if srv.HandleStopSignals {
+	if !srv.NoSignalHandling {
 		signal.Notify(srv.interrupt, syscall.SIGINT, syscall.SIGTERM)
 	}
 

--- a/graceful.go
+++ b/graceful.go
@@ -41,10 +41,15 @@ type Server struct {
 	// must not be set directly.
 	ConnState func(net.Conn, http.ConnState)
 
-	// ShutdownInitiated is an optional  callback function that is called
+	// ShutdownInitiated is an optional callback function that is called
 	// when shutdown is initiated. It can be used to notify the client
 	// side of long lived connections (e.g. websockets) to reconnect.
 	ShutdownInitiated func()
+
+	// DontAttachSignalHandler prevents graceful from automatically shutting down
+	// on SIGINT and SIGTERM. If set to true, you must shut down the server
+	// manually with Stop().
+	DontAttachSignalHandler bool
 
 	// interrupt signals the listener to stop serving connections,
 	// and the server to shut down.
@@ -213,8 +218,11 @@ func (srv *Server) Serve(listener net.Listener) error {
 		srv.interrupt = make(chan os.Signal, 1)
 	}
 
-	// Set up the interrupt catch
-	signal.Notify(srv.interrupt, syscall.SIGINT, syscall.SIGTERM)
+	// Set up the interrupt handler
+	if !srv.DontAttachSignalHandler {
+		signal.Notify(srv.interrupt, syscall.SIGINT, syscall.SIGTERM)
+	}
+
 	go func() {
 		<-srv.interrupt
 		srv.SetKeepAlivesEnabled(false)


### PR DESCRIPTION
If running multiple listeners in an application, you might need to shut them down in a certain order, or do other funky things.